### PR TITLE
Add Iterators

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/emretanriverdi/orderedmap
 
-go 1.18
+go 1.24
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/orderedmap.go
+++ b/orderedmap.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/goccy/go-json"
+	"iter"
 	"reflect"
 	"sort"
 	"sync"
@@ -116,6 +117,26 @@ func (om *orderedMap[K, V]) ForEach(f func(K, V)) {
 func (om *orderedMap[K, V]) ForEachReverse(f func(K, V)) {
 	for n := om.tail; n != nil; n = n.prev {
 		f(n.key, n.value)
+	}
+}
+
+func (om *orderedMap[K, V]) Iter() iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		for n := om.head; n != nil; n = n.next {
+			if !yield(n.key, n.value) {
+				break
+			}
+		}
+	}
+}
+
+func (om *orderedMap[K, V]) IterReverse() iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		for n := om.tail; n != nil; n = n.prev {
+			if !yield(n.key, n.value) {
+				break
+			}
+		}
 	}
 }
 

--- a/orderedmap_test.go
+++ b/orderedmap_test.go
@@ -198,6 +198,42 @@ func TestOrderedMap(t *testing.T) {
 		assert.Equal(t, []int{3, 2, 1}, values)
 	})
 
+	t.Run("Iter", func(t *testing.T) {
+		om := New[string, int]()
+		om.Set("first", 1)
+		om.Set("second", 2)
+		om.Set("third", 3)
+
+		var keys []string
+		var values []int
+
+		for k, v := range om.Iter() {
+			keys = append(keys, k)
+			values = append(values, v)
+		}
+
+		assert.Equal(t, []string{"first", "second", "third"}, keys)
+		assert.Equal(t, []int{1, 2, 3}, values)
+	})
+
+	t.Run("IterReverse", func(t *testing.T) {
+		om := New[string, int]()
+		om.Set("first", 1)
+		om.Set("second", 2)
+		om.Set("third", 3)
+
+		var keys []string
+		var values []int
+
+		for k, v := range om.IterReverse() {
+			keys = append(keys, k)
+			values = append(values, v)
+		}
+
+		assert.Equal(t, []string{"third", "second", "first"}, keys)
+		assert.Equal(t, []int{3, 2, 1}, values)
+	})
+
 	t.Run("ContainsKey", func(t *testing.T) {
 		om := New[string, int]()
 		om.Set("exists", 100)


### PR DESCRIPTION
Adds forward and reverse [iterators](https://pkg.go.dev/iter#Seq2) as an alternative to `ForEach`

Now rather than saying
```go
om.ForEach(func(k string, v int) bool {
	return false
})
```

You can use `for` directly.
```go
for k, v := range om.Iter() {
	break
}
```

This shallower scope gives the caller the flexibility to either `break` iteration or `return` from the parent scope during iteration.